### PR TITLE
This commit will catch the real print statements.

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -13,16 +13,8 @@ modified = re.compile('^[MA]\s+(?P<name>.*)$')
 
 CHECKS = [
     {
-        'output': 'Checking for pdbs...',
-        'command': 'grep -n "import pdb" %s',
-        'ignore_files': ['.*pre-commit'],
-        'print_filename': True,
-        'exists': False,
-        'package': ''
-    },
-    {
-        'output': 'Checking for ipdbs...',
-        'command': 'grep -n "import ipdb" %s',
+        'output': 'Checking for pdb and ipdbs...',
+        'command': 'grep -n "import [i]*pdb" %s',
         'ignore_files': ['.*pre-commit'],
         'print_filename': True,
         'exists': False,
@@ -30,7 +22,7 @@ CHECKS = [
     },
     {
         'output': 'Checking for print statements...',
-        'command': 'grep -n print %s',
+        'command': 'grep -n "^\s*\bprint" %s',
         'match_files': ['.*\.py$'],
         'ignore_files': ['.*migrations.*', '.*management/commands.*',
                          '.*manage.py', '.*/scripts/.*'],


### PR DESCRIPTION
Currently it is catching the import statements which has the print keyword
such as: from weasyprint import HTML
now it catch the real print statements.
Also no need to write 2 rules for pdb and ipdb. it can be catched with one regex.
